### PR TITLE
added Smart New Lines behaviour for handling block elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,17 @@
 var htmlparser = require("htmlparser2");
 var entities = require("entities");
 
+//list of block elements
+var blockElements = ['p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+
+//this flag turns on/off the NewLines handler
+// smartNewLines handler implies 
+//    a) each html block elements on its line
+//    b) \n written in source html are stripped away
+//For the sake of retro-compatibility, this flag is set to false
+// can be changed from the user by adding a parameter to the module's core function
+var smartNewLines = false;
+
 function walker(node, parameters, outerFont) {
 
   if (node.type === 'text') {
@@ -8,6 +19,9 @@ function walker(node, parameters, outerFont) {
 
   } else if (node.type === 'tag' && node.children) {
     var innerFont;
+
+    //flag for block elements
+    var isBlock = blockElements.indexOf(node.name) > -1;
 
     // clone font property from wrapping tags
     if (outerFont) {
@@ -38,10 +52,20 @@ function walker(node, parameters, outerFont) {
     // save length before children
     var offset = parameters.text.length;
 
+    //handle block elements to generate new line
+    // this is the prepended \n
+    if(smartNewLines && isBlock) parameters.text += '\n';
+
+
     // walk children
     node.children.forEach(function onEach(child) {
       parameters = walker(child, parameters, innerFont);
     });
+
+    //handle block elements to generate new line
+    // this is the appended \n
+    if(smartNewLines && isBlock) parameters.text += '\n';
+
 
     // calculate length of (grant)children text nodes
     var length = parameters.text.length - offset;
@@ -117,10 +141,26 @@ function walker(node, parameters, outerFont) {
     }
   }
 
+  //before returning paramenters, we need some cleaning on data
+  // text -> need to reduce multiple consecutives instances on \n into one 
+  //         it also strips spaces and tabs included in "new line"
+  if(smartNewLines)  parameters.text = parameters.text.replace(/\n[\n\s\t\r]*\n/gm, '\n');
+
   return parameters;
 }
 
-module.exports = function(html, callback) {
+
+/**
+ * Module's core function 
+ * 
+ * @param  {string}   html               source html to be processed
+ * @param  {Function} callback           callback function, in the form (err, result)
+ * @param  {boolean}   useSmartNewLines  flag to activate the Smart New Lines behaviour, which treats html block elements as new-line elements. Set to false for retro-compatibility (default: false)
+ */
+module.exports = function(html, callback, useSmartNewLines) {
+
+  //set module's parameter for using smartNewLines
+  smartNewLines = Boolean(useSmartNewLines);
 
   var parser = new htmlparser.Parser(new htmlparser.DomHandler(function(error, dom) {
 


### PR DESCRIPTION
As discussed in https://github.com/FokkeZB/ti-html2as/issues/18, these changes implements new line behaviour for block elements. This feature needs a flag to be activate, otherwise it works as before. 