### PR TITLE
Change min titaniumSDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/fokkezb/ti-html2as.git"
   },
   "engines": {
-    "titaniumsdk": ">= 3.3.0"
+    "titaniumsdk": ">= 3.6.0"
   },
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
I had a problem with Ti.UI.createAttributedString that seems to be unavailable in SDK 3.5.1 (???)
Docs here http://docs.appcelerator.com/platform/latest/#!/api/Titanium.UI-method-createAttributedString talks about SDK 3.6.0