### PR TITLE
Add custom matcher

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.zip
+coverage
 node_modules
 example/build
 example/Resources

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In Alloy you can use the [XP.UI](https://github.com/FokkeZB/UTiL/blob/master/doc
 	<Window>
 		<Label module="xp.ui" html="<font size=17>Hello <b>Bold</b> <font color=#FF0000>World!</font></font>" />
 	</Window>
-</Alloy> 
+</Alloy>
 ```
 
 Or you can use the [Widget](https://github.com/FokkeZB/nl.fokkezb.html2as.widget), which has the advantage that you can set the `html` property in a later stage as well:
@@ -61,7 +61,7 @@ Or you can use the [Widget](https://github.com/FokkeZB/nl.fokkezb.html2as.widget
 	<Window>
 		<Widget src="nl.fokkezb.html2as.widget" html="<font size=17>Hello <b>Bold</b> <font color=#FF0000>World!</font></font>" />
 	</Window>
-</Alloy> 
+</Alloy>
 ```
 
 ## Supported tags and attributes
@@ -75,11 +75,64 @@ Standard (old) HTML:
 * `<font face="Arial" size="12" color="red">`
 * `<a href="http://appcelerator.com">`
 
-Non-standard: 
+Non-standard:
 
 * `<effect>` (letterpress-style)
 * `<kern value="10">` (spacing between characters)
 * `<expansion value="0.5">` (stretch text horizontally)
+
+## Custom matcher
+The optional custom matcher allows parsing of non-standard tags and attributes.
+
+The function needs to return an object containing two properties:
+
+* `parameters` {Object} the parameters property passed into the function with any additions
+* `continue` {Boolean} whether to continue through the default matchers
+
+### Custom matcher example
+To style H1 tags:
+
+```
+var customMatcher = function(node, parameters, outerFont, offset, length, ns) {
+  if (node.type === 'tag' && node.name && node.name === 'h1') {
+    parameters.attributes.unshift({
+      type: ns.ATTRIBUTE_FOREGROUND_COLOR,
+      value: Alloy.CFG.h1Color,
+      range: [offset, length]
+    });
+    parameters.attributes.unshift({
+      type: ns.ATTRIBUTE_FONT,
+      value: {
+        fontSize: Alloy.CFG.h1FontSize,
+        fontFamily: Alloy.CFG.h1FontFamily
+      },
+      range: [offset, length]
+    });
+  }
+
+  return {
+    parameters: parameters,
+    continue: true
+  };
+}
+
+var html2as = require('nl.fokkezb.html2as');
+
+html2as(
+	'<h1>Hello World</h1>',
+	function(err, as) {
+
+		if (err) {
+			console.error(err);
+		} else {
+			view.add(Titanium.UI.createLabel({
+				attributedString: as
+			}));
+		}
+	},
+	customMatcher
+);
+```
 
 ## Example
 The [example](example) folder includes a Titanium project demonstrating the module. To build the module and then run the example project use the included grunt tasks:

--- a/index.js
+++ b/index.js
@@ -1,28 +1,6 @@
 var htmlparser = require("htmlparser2");
 var entities = require("entities");
 
-// Custom matcher function to enable parsing of extra node types.
-// @return Array|false
-// @example
-//   function(node, parameters, outerFont, offset, length, ns) {
-//     if (node.type === 'type' && node.name && node.name === 'h1') {
-//       return [{
-//         type: ns.ATTRIBUTE_FOREGROUND_COLOR,
-//         value: Alloy.CFG.h1Color,
-//         range: [offset, length]
-//       }, {
-//         type: ns.ATTRIBUTE_FONT,
-//         value: {
-//           fontSize: Alloy.CFG.h1FontSize,
-//           fontFamily: Alloy.CFG.h1FontFamily
-//         },
-//         range: [offset, length]
-//       }];
-//     }
-//     return false;
-//   }
-var customMatcher = null;
-
 // References to the full namespace to they get packaged for device builds
 var references = [
   Ti.UI.AttributedString
@@ -37,7 +15,33 @@ if (parseInt(Ti.version.split('.')[0], 10) < 4) {
 
 var ios = Ti.Platform.name === 'iPhone OS';
 
-function walker(node, parameters, outerFont) {
+// Custom matcher is a function to enable parsing of extra node types.
+// @return Object
+// @property parameters Object
+// @property continue Boolean
+// @example
+//   function(node, parameters, outerFont, offset, length, ns) {
+//     if (node.type === 'tag' && node.name && node.name === 'h1') {
+//       parameters.attributes.unshift({
+//         type: ns.ATTRIBUTE_FOREGROUND_COLOR,
+//         value: Alloy.CFG.h1Color,
+//         range: [offset, length]
+//       });
+//       parameters.attributes.unshift({
+//         type: ns.ATTRIBUTE_FONT,
+//         value: {
+//           fontSize: Alloy.CFG.h1FontSize,
+//           fontFamily: Alloy.CFG.h1FontFamily
+//         },
+//         range: [offset, length]
+//       });
+//     }
+//     return {
+//       parameters: parameters,
+//       continue: true
+//     };
+//   }
+function walker(node, parameters, outerFont, customMatcher) {
 
   if (node.type === 'text') {
     parameters.text += entities.decodeHTML(node.data);
@@ -76,11 +80,25 @@ function walker(node, parameters, outerFont) {
 
     // walk children
     node.children.forEach(function onEach(child) {
-      parameters = walker(child, parameters, innerFont);
+      parameters = walker(child, parameters, innerFont, customMatcher);
     });
 
     // calculate length of (grant)children text nodes
     var length = parameters.text.length - offset;
+
+    if (typeof customMatcher === 'function') {
+      var customMatch = customMatcher(node, parameters, outerFont, offset, length, ns);
+
+      if (customMatch.parameters === undefined || customMatch.continue === undefined) {
+        throw new Error('customMatcher should return an object with parameters and continue properties defined');
+      }
+
+      parameters = customMatch.parameters;
+
+      if (customMatch.continue === false) {
+        return parameters;
+      }
+    }
 
     // only apply attributes if we wrap text
     if (length > 0) {
@@ -140,33 +158,23 @@ function walker(node, parameters, outerFont) {
           value: node.attribs.color,
           range: [offset, length]
         });
-      } else if (customMatcher !== null) {
-        var res = customMatcher(node, parameters, outerFont, offset, length, ns);
-
-        if (res !== false) {
-          parameters.attributes = res.concat(parameters.attributes);
-        }
       }
+    }
 
-      // if we have a font to set
-      if (innerFont) {
-        parameters.attributes.unshift({
-          type: ns.ATTRIBUTE_FONT,
-          value: innerFont,
-          range: [offset, length]
-        });
-      }
+    // if we have a font to set
+    if (innerFont) {
+      parameters.attributes.unshift({
+        type: ns.ATTRIBUTE_FONT,
+        value: innerFont,
+        range: [offset, length]
+      });
     }
   }
 
   return parameters;
 }
 
-module.exports = function(html, callback, matcher) {
-  if (matcher && typeof matcher === 'function') {
-    customMatcher = matcher;
-  }
-
+module.exports = function(html, callback, customMatcher) {
   var parser = new htmlparser.Parser(new htmlparser.DomHandler(function(error, dom) {
 
     if (error) {
@@ -180,7 +188,7 @@ module.exports = function(html, callback, matcher) {
       }, {
         text: '',
         attributes: []
-      });
+    }, null, customMatcher);
 
       var attr = ns.createAttributedString(parameters);
 

--- a/package.json
+++ b/package.json
@@ -29,16 +29,22 @@
     "attributed",
     "string"
   ],
+  "scripts": {
+    "test": "istanbul cover jasmine"
+  },
   "dependencies": {
     "entities": "^1.1.1",
     "grunt-titaniumifier": "^1.1.0",
     "htmlparser2": "^3.8.0"
   },
   "devDependencies": {
+    "grunt": "^0.4.2",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-titanium": "fokkezb/grunt-titanium#patch-3",
     "grunt-titaniumifier": "^1.0.0-beta",
     "grunt-zip": "^0.16.0",
-    "grunt": "^0.4.2"
+    "istanbul": "^0.4.2",
+    "jasmine": "^2.4.1",
+    "proxyquire": "^1.7.4"
   }
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,7 @@
+{
+    "spec_dir": "test/specs",
+    "spec_files": [
+        "**/*[sS]pec.js"
+    ],
+    "helpers": []
+}

--- a/test/specs/indexSpec.js
+++ b/test/specs/indexSpec.js
@@ -1,0 +1,707 @@
+var proxyquire = require('proxyquire').noCallThru();
+
+describe('html2as - standard functioinality -', function() {
+  var html2as = null;
+
+  beforeEach(function() {
+    Ti = require('../spies/TiSpy')();
+  });
+
+  function init() {
+    html2as = proxyquire('../../index', {});
+  }
+
+  afterEach(function() {
+    delete Ti;
+  });
+
+  it('correctly parses known html tags to the correct AttributedString values - iOS - Ti 5.2.0', function() {
+    Ti.version = '5.2.0';
+
+    Ti.Platform.name = 'iPhone OS';
+
+    init();
+
+    Ti.UI.createAttributedString.and.callFake(function(parameters) {
+      return parameters;
+    });
+
+    var callbackExecuted = false;
+    var callback = function(err, result) {
+      expect(err).toBeNull();
+      expect(result).toEqual({
+        text: 'Strong Text\nBold Text\nUnderlined Text\nEmphasised Text\nItalicised Text\nStruck (strike) Text\nDeleted Text\nStruck (s) Text\nArial Text\nFont size 12 Text\nRed Text\nAnchor\nLetterpress Text\nKerned Text\nExpanded Text',
+        attributes: [{
+          type: 20,
+          value: '0.5',
+          range: [194, 13]
+        }, {
+          type: 5,
+          value: '10',
+          range: [182, 11]
+        }, {
+          type: 13,
+          value: '_UIKitNewLetterpressStyle',
+          range: [165, 16]
+        }, {
+          type: 15,
+          value: 'https://github.com/FokkeZB/ti-html2as',
+          range: [158, 6]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [149, 8]
+        }, {
+          type: 0,
+          value: {
+            fontSize: '12'
+          },
+          range: [131, 17]
+        }, {
+          type: 0,
+          value: {
+            fontFamily: 'Arial'
+          },
+          range: [120, 10]
+        }, {
+          type: 6,
+          value: 1,
+          range: [104, 15]
+        }, {
+          type: 6,
+          value: 1,
+          range: [91, 12]
+        }, {
+          type: 6,
+          value: 1,
+          range: [70, 20]
+        }, {
+          type: 19,
+          value: 0.25,
+          range: [54, 15]
+        }, {
+          type: 19,
+          value: 0.25,
+          range: [38, 15]
+        }, {
+          type: 7,
+          value: 1,
+          range: [22, 15]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [12, 9]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [0, 11]
+        }]
+      });
+
+      callbackExecuted = true;
+    };
+
+    var html = '<strong>Strong Text</strong><br>' +
+      '<b>Bold Text</b><br>' +
+      '<u>Underlined Text</u><br>' +
+      '<em>Emphasised Text</em><br>' +
+      '<i>Italicised Text</i><br>' +
+      '<strike>Struck (strike) Text</strike><br>' +
+      '<del>Deleted Text</del><br>' +
+      '<s>Struck (s) Text</s><br>' +
+      '<font face="Arial">Arial Text</font><br>' +
+      '<font size="12">Font size 12 Text</font><br>' +
+      '<font color="red">Red Text</font><br>' +
+      '<a href="https://github.com/FokkeZB/ti-html2as">Anchor</a><br>' +
+      '<effect>Letterpress Text</effect><br>' +
+      '<kern value="10">Kerned Text</kern><br>' +
+      '<expansion value="0.5">Expanded Text</expansion>';
+
+    html2as(html, callback);
+
+    expect(callbackExecuted).toBeTruthy();
+  });
+
+  it('correctly parses known html tags to the correct AttributedString values - iOS - Ti 3.5.1', function() {
+    Ti.version = '3.5.1';
+
+    Ti.Platform.name = 'iPhone OS';
+
+    init();
+
+    Ti.UI.createAttributedString.and.callFake(function(parameters) {
+      return parameters;
+    });
+
+    var callbackExecuted = false;
+    var callback = function(err, result) {
+      expect(err).toBeNull();
+      expect(result).toEqual({
+        text: 'Strong Text\nBold Text\nUnderlined Text\nEmphasised Text\nItalicised Text\nStruck (strike) Text\nDeleted Text\nStruck (s) Text\nArial Text\nFont size 12 Text\nRed Text\nAnchor\nLetterpress Text\nKerned Text\nExpanded Text',
+        attributes: [{
+          type: 20,
+          value: '0.5',
+          range: [194, 13]
+        }, {
+          type: 5,
+          value: '10',
+          range: [182, 11]
+        }, {
+          type: 13,
+          value: '_UIKitNewLetterpressStyle',
+          range: [165, 16]
+        }, {
+          type: 15,
+          value: 'https://github.com/FokkeZB/ti-html2as',
+          range: [158, 6]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [149, 8]
+        }, {
+          type: 0,
+          value: {
+            fontSize: '12'
+          },
+          range: [131, 17]
+        }, {
+          type: 0,
+          value: {
+            fontFamily: 'Arial'
+          },
+          range: [120, 10]
+        }, {
+          type: 6,
+          value: 1,
+          range: [104, 15]
+        }, {
+          type: 6,
+          value: 1,
+          range: [91, 12]
+        }, {
+          type: 6,
+          value: 1,
+          range: [70, 20]
+        }, {
+          type: 19,
+          value: 0.25,
+          range: [54, 15]
+        }, {
+          type: 19,
+          value: 0.25,
+          range: [38, 15]
+        }, {
+          type: 7,
+          value: 1,
+          range: [22, 15]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [12, 9]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [0, 11]
+        }]
+      });
+
+      callbackExecuted = true;
+    };
+
+    var html = '<strong>Strong Text</strong><br>' +
+      '<b>Bold Text</b><br>' +
+      '<u>Underlined Text</u><br>' +
+      '<em>Emphasised Text</em><br>' +
+      '<i>Italicised Text</i><br>' +
+      '<strike>Struck (strike) Text</strike><br>' +
+      '<del>Deleted Text</del><br>' +
+      '<s>Struck (s) Text</s><br>' +
+      '<font face="Arial">Arial Text</font><br>' +
+      '<font size="12">Font size 12 Text</font><br>' +
+      '<font color="red">Red Text</font><br>' +
+      '<a href="https://github.com/FokkeZB/ti-html2as">Anchor</a><br>' +
+      '<effect>Letterpress Text</effect><br>' +
+      '<kern value="10">Kerned Text</kern><br>' +
+      '<expansion value="0.5">Expanded Text</expansion>';
+
+    html2as(html, callback);
+
+    expect(callbackExecuted).toBeTruthy();
+  });
+
+  it('correctly parses known html tags to the correct AttributedString values - Android - Ti 5.2.0', function() {
+    Ti.version = '5.2.0';
+
+    Ti.Platform.name = 'Android OS';
+
+    init();
+
+    Ti.UI.createAttributedString.and.callFake(function(parameters) {
+      return parameters;
+    });
+
+    var callbackExecuted = false;
+    var callback = function(err, result) {
+      expect(err).toBeNull();
+      expect(result).toEqual({
+        text: 'Strong Text\nBold Text\nUnderlined Text\nEmphasised Text\nItalicised Text\nStruck (strike) Text\nDeleted Text\nStruck (s) Text\nArial Text\nFont size 12 Text\nRed Text\nAnchor\nLetterpress Text\nKerned Text\nExpanded Text',
+        attributes: [{
+          type: 15,
+          value: 'https://github.com/FokkeZB/ti-html2as',
+          range: [158, 6]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [149, 8]
+        }, {
+          type: 0,
+          value: {
+            fontSize: '12'
+          },
+          range: [131, 17]
+        }, {
+          type: 0,
+          value: {
+            fontFamily: 'Arial'
+          },
+          range: [120, 10]
+        }, {
+          type: 6,
+          value: undefined,
+          range: [104, 15]
+        }, {
+          type: 6,
+          value: undefined,
+          range: [91, 12]
+        }, {
+          type: 6,
+          value: undefined,
+          range: [70, 20]
+        }, {
+          type: 7,
+          value: undefined,
+          range: [22, 15]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [12, 9]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [0, 11]
+        }]
+      });
+
+      callbackExecuted = true;
+    };
+
+    var html = '<strong>Strong Text</strong><br>' +
+      '<b>Bold Text</b><br>' +
+      '<u>Underlined Text</u><br>' +
+      '<em>Emphasised Text</em><br>' +
+      '<i>Italicised Text</i><br>' +
+      '<strike>Struck (strike) Text</strike><br>' +
+      '<del>Deleted Text</del><br>' +
+      '<s>Struck (s) Text</s><br>' +
+      '<font face="Arial">Arial Text</font><br>' +
+      '<font size="12">Font size 12 Text</font><br>' +
+      '<font color="red">Red Text</font><br>' +
+      '<a href="https://github.com/FokkeZB/ti-html2as">Anchor</a><br>' +
+      '<effect>Letterpress Text</effect><br>' +
+      '<kern value="10">Kerned Text</kern><br>' +
+      '<expansion value="0.5">Expanded Text</expansion>';
+
+    html2as(html, callback);
+
+    expect(callbackExecuted).toBeTruthy();
+  });
+
+  it('correctly parses known html tags to the correct AttributedString values - nested tags - Android - Ti 5.2.0', function() {
+    Ti.version = '5.2.0';
+
+    Ti.Platform.name = 'Android OS';
+
+    init();
+
+    Ti.UI.createAttributedString.and.callFake(function(parameters) {
+      return parameters;
+    });
+
+    var callbackExecuted = false;
+    var callback = function(err, result) {
+      expect(err).toBeNull();
+      expect(result).toEqual({
+        text: 'Strong Text with some Italicised Text and some Underlined Text',
+        attributes: [{
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [0, 62]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [47, 15]
+        }, {
+          type: 7,
+          value: undefined,
+          range: [47, 15]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [22, 15]
+        }]
+      });
+
+      callbackExecuted = true;
+    };
+
+    var html = '<strong>Strong Text with some <i>Italicised Text</i> and some <u>Underlined Text</u></strong>';
+
+    html2as(html, callback);
+
+    expect(callbackExecuted).toBeTruthy();
+  });
+});
+
+describe('html2as - custom functioinality -', function() {
+  var html2as = null;
+
+  beforeEach(function() {
+    Ti = require('../spies/TiSpy')();
+  });
+
+  function init() {
+    html2as = proxyquire('../../index', {});
+  }
+
+  afterEach(function() {
+    delete Ti;
+  });
+
+  it('correctly parses known html tags and custom html tags to the correct AttributedString values - iOS - Ti 5.2.0', function() {
+    Ti.version = '5.2.0';
+
+    Ti.Platform.name = 'iPhone OS';
+
+    init();
+
+    Ti.UI.createAttributedString.and.callFake(function(parameters) {
+      return parameters;
+    });
+
+    var customMatcher = function(node, parameters, outerFont, offset, length, ns) {
+      if (node.type === 'tag' && node.name && node.name === 'h1') {
+        parameters.attributes.unshift({
+          type: ns.ATTRIBUTE_FOREGROUND_COLOR,
+          value: 'red',
+          range: [offset, length]
+        });
+        parameters.attributes.unshift({
+          type: ns.ATTRIBUTE_FONT,
+          value: {
+            fontSize: 48,
+            fontFamily: 'Arial'
+          },
+          range: [offset, length]
+        });
+      }
+
+      return {
+        parameters: parameters,
+        continue: true
+      };
+    };
+
+    var callbackExecuted = false;
+    var callback = function(err, result) {
+      expect(err).toBeNull();
+      expect(result).toEqual({
+        text: 'Strong Text\nBold Text\nUnderlined Text\nEmphasised Text\nItalicised Text\nStruck (strike) Text\nDeleted Text\nStruck (s) Text\nArial Text\nFont size 12 Text\nRed Text\nAnchor\nLetterpress Text\nKerned Text\nExpanded Text\nH1 Text',
+        attributes: [{
+          type: 0,
+          value: {
+            fontSize: 48,
+            fontFamily: 'Arial'
+          },
+          range: [208, 7]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [208, 7]
+        }, {
+          type: 20,
+          value: '0.5',
+          range: [194, 13]
+        }, {
+          type: 5,
+          value: '10',
+          range: [182, 11]
+        }, {
+          type: 13,
+          value: '_UIKitNewLetterpressStyle',
+          range: [165, 16]
+        }, {
+          type: 15,
+          value: 'https://github.com/FokkeZB/ti-html2as',
+          range: [158, 6]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [149, 8]
+        }, {
+          type: 0,
+          value: {
+            fontSize: '12'
+          },
+          range: [131, 17]
+        }, {
+          type: 0,
+          value: {
+            fontFamily: 'Arial'
+          },
+          range: [120, 10]
+        }, {
+          type: 6,
+          value: 1,
+          range: [104, 15]
+        }, {
+          type: 6,
+          value: 1,
+          range: [91, 12]
+        }, {
+          type: 6,
+          value: 1,
+          range: [70, 20]
+        }, {
+          type: 19,
+          value: 0.25,
+          range: [54, 15]
+        }, {
+          type: 19,
+          value: 0.25,
+          range: [38, 15]
+        }, {
+          type: 7,
+          value: 1,
+          range: [22, 15]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [12, 9]
+        }, {
+          type: 0,
+          value: {
+            fontWeight: 'bold'
+          },
+          range: [0, 11]
+        }]
+      });
+
+      callbackExecuted = true;
+    };
+
+    var html = '<strong>Strong Text</strong><br>' +
+      '<b>Bold Text</b><br>' +
+      '<u>Underlined Text</u><br>' +
+      '<em>Emphasised Text</em><br>' +
+      '<i>Italicised Text</i><br>' +
+      '<strike>Struck (strike) Text</strike><br>' +
+      '<del>Deleted Text</del><br>' +
+      '<s>Struck (s) Text</s><br>' +
+      '<font face="Arial">Arial Text</font><br>' +
+      '<font size="12">Font size 12 Text</font><br>' +
+      '<font color="red">Red Text</font><br>' +
+      '<a href="https://github.com/FokkeZB/ti-html2as">Anchor</a><br>' +
+      '<effect>Letterpress Text</effect><br>' +
+      '<kern value="10">Kerned Text</kern><br>' +
+      '<expansion value="0.5">Expanded Text</expansion><br>' +
+      '<h1>H1 Text</h1>';
+
+    html2as(html, callback, customMatcher);
+
+    expect(callbackExecuted).toBeTruthy();
+  });
+
+  it('correctly parses custom html tags, without continuing, to the correct AttributedString values - iOS - Ti 5.2.0', function() {
+    Ti.version = '5.2.0';
+
+    Ti.Platform.name = 'iPhone OS';
+
+    init();
+
+    Ti.UI.createAttributedString.and.callFake(function(parameters) {
+      return parameters;
+    });
+
+    var customMatcher = function(node, parameters, outerFont, offset, length, ns) {
+
+      if (node.type === 'tag' && node.name && node.name !== 'h1') {
+        parameters.attributes.unshift({
+          type: ns.ATTRIBUTE_FOREGROUND_COLOR,
+          value: 'red',
+          range: [offset, length]
+        });
+      }
+
+      return {
+        parameters: parameters,
+        continue: false
+      };
+    };
+
+    var callbackExecuted = false;
+    var callback = function(err, result) {
+      expect(err).toBeNull();
+      expect(result).toEqual({
+        text: 'Strong Text\nBold Text\nUnderlined Text\nEmphasised Text\nItalicised Text\nStruck (strike) Text\nDeleted Text\nStruck (s) Text\nArial Text\nFont size 12 Text\nRed Text\nAnchor\nLetterpress Text\nKerned Text\nExpanded Text\nH1 Text',
+        attributes: [{
+          type: 2,
+          value: 'red',
+          range: [194, 13]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [182, 11]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [165, 16]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [158, 6]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [149, 8]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [131, 17]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [120, 10]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [104, 15]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [91, 12]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [70, 20]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [54, 15]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [38, 15]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [22, 15]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [12, 9]
+        }, {
+          type: 2,
+          value: 'red',
+          range: [0, 11]
+        }]
+      });
+
+      callbackExecuted = true;
+    };
+
+    var html = '<strong>Strong Text</strong><br>' +
+      '<b>Bold Text</b><br>' +
+      '<u>Underlined Text</u><br>' +
+      '<em>Emphasised Text</em><br>' +
+      '<i>Italicised Text</i><br>' +
+      '<strike>Struck (strike) Text</strike><br>' +
+      '<del>Deleted Text</del><br>' +
+      '<s>Struck (s) Text</s><br>' +
+      '<font face="Arial">Arial Text</font><br>' +
+      '<font size="12">Font size 12 Text</font><br>' +
+      '<font color="red">Red Text</font><br>' +
+      '<a href="https://github.com/FokkeZB/ti-html2as">Anchor</a><br>' +
+      '<effect>Letterpress Text</effect><br>' +
+      '<kern value="10">Kerned Text</kern><br>' +
+      '<expansion value="0.5">Expanded Text</expansion><br>' +
+      '<h1>H1 Text</h1>';
+
+    html2as(html, callback, customMatcher);
+
+    expect(callbackExecuted).toBeTruthy();
+  });
+
+  it('throws an error for a custom matcher which doesn\'t return the required parameters - iOS - Ti 5.2.0', function() {
+    Ti.version = '5.2.0';
+
+    Ti.Platform.name = 'iPhone OS';
+
+    init();
+
+    Ti.UI.createAttributedString.and.callFake(function(parameters) {
+      return parameters;
+    });
+
+    var customMatcher = function(node, parameters, outerFont, ns) {
+      return false;
+    };
+
+    var callbackExecuted = false;
+    var callback = function() {
+      callbackExecuted = true;
+    };
+
+    var html = '<strong>Strong Text</strong><br>' +
+      '<b>Bold Text</b><br>' +
+      '<u>Underlined Text</u><br>' +
+      '<em>Emphasised Text</em><br>' +
+      '<i>Italicised Text</i><br>' +
+      '<strike>Struck (strike) Text</strike><br>' +
+      '<del>Deleted Text</del><br>' +
+      '<s>Struck (s) Text</s><br>' +
+      '<font face="Arial">Arial Text</font><br>' +
+      '<font size="12">Font size 12 Text</font><br>' +
+      '<font color="red">Red Text</font><br>' +
+      '<a href="https://github.com/FokkeZB/ti-html2as">Anchor</a><br>' +
+      '<effect>Letterpress Text</effect><br>' +
+      '<kern value="10">Kerned Text</kern><br>' +
+      '<expansion value="0.5">Expanded Text</expansion><br>' +
+      '<h1>H1 Text</h1>';
+
+    expect(function() {
+      html2as(html, callback, customMatcher);
+    }).toThrowError('customMatcher should return an object with parameters and continue properties defined');
+
+    expect(callbackExecuted).toBeFalsy();
+  });
+});

--- a/test/spies/TiSpy.js
+++ b/test/spies/TiSpy.js
@@ -1,0 +1,248 @@
+module.exports = function() {
+  var TiSpy = jasmine.createSpyObj('TiSpy', [
+    'addEventListener',
+    'applyProperties',
+    'createBuffer',
+    'createProxy',
+    'fireEvent',
+    'getApiName',
+    'getBubbleParent',
+    'getBuildDate',
+    'getBuildHash',
+    'getLifecycleContainer',
+    'getUserAgent',
+    'getVersion',
+    'removeEventListener',
+    'setBubbleParent',
+    'setLifecycleContainer',
+    'setUserAgent'
+  ]);
+
+  TiSpy.version = '5.2.0';
+  TiSpy.Platform = {
+    name: 'iPhone OS'
+  };
+  TiSpy.iOS = {};
+
+  var TiUISpy = jasmine.createSpyObj('TiUISpy', [
+    'addEventListener',
+    'applyProperties',
+    'convertUnits',
+    'create2DMatrix',
+    'create3DMatrix',
+    'createActivityIndicator',
+    'createAlertDialog',
+    'createAnimation',
+    'createAttributedString',
+    'createButton',
+    'createButtonBar',
+    'createDashboardItem',
+    'createDashboardView',
+    'createEmailDialog',
+    'createImageView',
+    'createLabel',
+    'createListSection',
+    'createListView',
+    'createMaskedImage',
+    'createNotification',
+    'createOptionDialog',
+    'createPicker',
+    'createPickerColumn',
+    'createPickerRow',
+    'createProgressBar',
+    'createRefreshControl',
+    'createScrollView',
+    'createScrollableView',
+    'createSearchBar',
+    'createSlider',
+    'createSwitch',
+    'createTab',
+    'createTabGroup',
+    'createTableView',
+    'createTableViewRow',
+    'createTableViewSection',
+    'createTextArea',
+    'createTextField',
+    'createView',
+    'createWebView',
+    'createWindow',
+    'fireEvent',
+    'getApiName',
+    'getBackgroundColor',
+    'getBackgroundImage',
+    'getBubbleParent',
+    'getCurrentTab',
+    'getCurrentWindow',
+    'getLifecycleContainer',
+    'removeEventListener',
+    'setBackgroundColor',
+    'setBackgroundImage',
+    'setBubbleParent',
+    'setCurrentTab',
+    'setLifecycleContainer'
+  ]);
+
+  TiUISpy.ANIMATION_CURVE_EASE_IN = 65536;
+  TiUISpy.ANIMATION_CURVE_EASE_IN_OUT = 0;
+  TiUISpy.ANIMATION_CURVE_EASE_OUT = 131072;
+  TiUISpy.ANIMATION_CURVE_LINEAR = 196608;
+  TiUISpy.ATTRIBUTE_BACKGROUND_COLOR = 3;
+  TiUISpy.ATTRIBUTE_BASELINE_OFFSET = 16;
+  TiUISpy.ATTRIBUTE_EXPANSION = 20;
+  TiUISpy.ATTRIBUTE_FONT = 0;
+  TiUISpy.ATTRIBUTE_FOREGROUND_COLOR = 2;
+  TiUISpy.ATTRIBUTE_KERN = 5;
+  TiUISpy.ATTRIBUTE_LETTERPRESS_STYLE = '_UIKitNewLetterpressStyle';
+  TiUISpy.ATTRIBUTE_LIGATURE = 4;
+  TiUISpy.ATTRIBUTE_LINE_BREAK = 21;
+  TiUISpy.ATTRIBUTE_LINE_BREAK_BY_CHAR_WRAPPING = 1;
+  TiUISpy.ATTRIBUTE_LINE_BREAK_BY_CLIPPING = 2;
+  TiUISpy.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_HEAD = 3;
+  TiUISpy.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_MIDDLE = 5;
+  TiUISpy.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_TAIL = 4;
+  TiUISpy.ATTRIBUTE_LINE_BREAK_BY_WORD_WRAPPING = 0;
+  TiUISpy.ATTRIBUTE_LINK = 15;
+  TiUISpy.ATTRIBUTE_OBLIQUENESS = 19;
+  TiUISpy.ATTRIBUTE_SHADOW = 10;
+  TiUISpy.ATTRIBUTE_STRIKETHROUGH_COLOR = 18;
+  TiUISpy.ATTRIBUTE_STRIKETHROUGH_STYLE = 6;
+  TiUISpy.ATTRIBUTE_STROKE_COLOR = 8;
+  TiUISpy.ATTRIBUTE_STROKE_WIDTH = 9;
+  TiUISpy.ATTRIBUTE_TEXT_EFFECT = 13;
+  TiUISpy.ATTRIBUTE_UNDERLINES_STYLE = 7;
+  TiUISpy.ATTRIBUTE_UNDERLINE_BY_WORD = 32768;
+  TiUISpy.ATTRIBUTE_UNDERLINE_COLOR = 17;
+  TiUISpy.ATTRIBUTE_UNDERLINE_PATTERN_DASH = 512;
+  TiUISpy.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT = 768;
+  TiUISpy.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT = 1024;
+  TiUISpy.ATTRIBUTE_UNDERLINE_PATTERN_DOT = 256;
+  TiUISpy.ATTRIBUTE_UNDERLINE_PATTERN_SOLID = 0;
+  TiUISpy.ATTRIBUTE_UNDERLINE_STYLE_DOUBLE = 9;
+  TiUISpy.ATTRIBUTE_UNDERLINE_STYLE_NONE = 0;
+  TiUISpy.ATTRIBUTE_UNDERLINE_STYLE_SINGLE = 1;
+  TiUISpy.ATTRIBUTE_UNDERLINE_STYLE_THICK = 2;
+  TiUISpy.ATTRIBUTE_WRITING_DIRECTION = 12;
+  TiUISpy.ATTRIBUTE_WRITING_DIRECTION_EMBEDDING = 0;
+  TiUISpy.ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT = 0;
+  TiUISpy.ATTRIBUTE_WRITING_DIRECTION_NATURAL = -1;
+  TiUISpy.ATTRIBUTE_WRITING_DIRECTION_OVERRIDE = 2;
+  TiUISpy.ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT = 1;
+  TiUISpy.AUTOLINK_ALL = 18446744073709552000;
+  TiUISpy.AUTOLINK_CALENDAR = 8;
+  TiUISpy.AUTOLINK_EMAIL_ADDRESSES = 2;
+  TiUISpy.AUTOLINK_MAP_ADDRESSES = 4;
+  TiUISpy.AUTOLINK_NONE = 0;
+  TiUISpy.AUTOLINK_PHONE_NUMBERS = 1;
+  TiUISpy.AUTOLINK_URLS = 2;
+  TiUISpy.EXTEND_EDGE_ALL = 15;
+  TiUISpy.EXTEND_EDGE_BOTTOM = 4;
+  TiUISpy.EXTEND_EDGE_LEFT = 2;
+  TiUISpy.EXTEND_EDGE_NONE = 0;
+  TiUISpy.EXTEND_EDGE_RIGHT = 8;
+  TiUISpy.EXTEND_EDGE_TOP = 1;
+  TiUISpy.FACE_DOWN = 6;
+  TiUISpy.FACE_UP = 5;
+  TiUISpy.FILL = 'FILL';
+  TiUISpy.INPUT_BORDERSTYLE_BEZEL = 2;
+  TiUISpy.INPUT_BORDERSTYLE_LINE = 1;
+  TiUISpy.INPUT_BORDERSTYLE_NONE = 0;
+  TiUISpy.INPUT_BORDERSTYLE_ROUNDED = 3;
+  TiUISpy.INPUT_BUTTONMODE_ALWAYS = 3;
+  TiUISpy.INPUT_BUTTONMODE_NEVER = 0;
+  TiUISpy.INPUT_BUTTONMODE_ONBLUR = 2;
+  TiUISpy.INPUT_BUTTONMODE_ONFOCUS = 1;
+  TiUISpy.INPUT_TYPE_CLASS_NUMBER = undefined;
+  TiUISpy.INPUT_TYPE_CLASS_TEXT = undefined;
+  TiUISpy.KEYBOARD_APPEARANCE_DARK = 1;
+  TiUISpy.KEYBOARD_APPEARANCE_DEFAULT = 0;
+  TiUISpy.KEYBOARD_APPEARANCE_LIGHT = 2;
+  TiUISpy.KEYBOARD_TYPE_ASCII = 1;
+  TiUISpy.KEYBOARD_TYPE_DECIMAL_PAD = 8;
+  TiUISpy.KEYBOARD_TYPE_DEFAULT = 0;
+  TiUISpy.KEYBOARD_TYPE_EMAIL = 7;
+  TiUISpy.KEYBOARD_TYPE_NAMEPHONE_PAD = 6;
+  TiUISpy.KEYBOARD_TYPE_NUMBERS_PUNCTUATION = 2;
+  TiUISpy.KEYBOARD_TYPE_NUMBER_PAD = 4;
+  TiUISpy.KEYBOARD_TYPE_PHONE_PAD = 5;
+  TiUISpy.KEYBOARD_TYPE_TWITTER = 9;
+  TiUISpy.KEYBOARD_TYPE_URL = 3;
+  TiUISpy.KEYBOARD_TYPE_WEBSEARCH = 10;
+  TiUISpy.LANDSCAPE_LEFT = 4;
+  TiUISpy.LANDSCAPE_RIGHT = 3;
+  TiUISpy.LIST_ACCESSORY_TYPE_CHECKMARK = 3;
+  TiUISpy.LIST_ACCESSORY_TYPE_DETAIL = 2;
+  TiUISpy.LIST_ACCESSORY_TYPE_DISCLOSURE = 1;
+  TiUISpy.LIST_ACCESSORY_TYPE_NONE = 0;
+  TiUISpy.LIST_ITEM_TEMPLATE_CONTACTS = 2;
+  TiUISpy.LIST_ITEM_TEMPLATE_DEFAULT = 0;
+  TiUISpy.LIST_ITEM_TEMPLATE_SETTINGS = 1;
+  TiUISpy.LIST_ITEM_TEMPLATE_SUBTITLE = 3;
+  TiUISpy.NOTIFICATION_DURATION_LONG = undefined;
+  TiUISpy.NOTIFICATION_DURATION_SHORT = undefined;
+  TiUISpy.PICKER_TYPE_COUNT_DOWN_TIMER = 3;
+  TiUISpy.PICKER_TYPE_DATE = 1;
+  TiUISpy.PICKER_TYPE_DATE_AND_TIME = 2;
+  TiUISpy.PICKER_TYPE_PLAIN = -1;
+  TiUISpy.PICKER_TYPE_TIME = 0;
+  TiUISpy.PORTRAIT = 1;
+  TiUISpy.RETURNKEY_CONTINUE = 11;
+  TiUISpy.RETURNKEY_DEFAULT = 0;
+  TiUISpy.RETURNKEY_DONE = 9;
+  TiUISpy.RETURNKEY_EMERGENCY_CALL = 10;
+  TiUISpy.RETURNKEY_GO = 1;
+  TiUISpy.RETURNKEY_GOOGLE = 2;
+  TiUISpy.RETURNKEY_JOIN = 3;
+  TiUISpy.RETURNKEY_NEXT = 4;
+  TiUISpy.RETURNKEY_ROUTE = 5;
+  TiUISpy.RETURNKEY_SEARCH = 6;
+  TiUISpy.RETURNKEY_SEND = 7;
+  TiUISpy.RETURNKEY_YAHOO = 8;
+  TiUISpy.SIZE = 'SIZE';
+  TiUISpy.TABLE_VIEW_SEPARATOR_STYLE_NONE = undefined;
+  TiUISpy.TABLE_VIEW_SEPARATOR_STYLE_SINGLE_LINE = undefined;
+  TiUISpy.TEXT_ALIGNMENT_CENTER = 1;
+  TiUISpy.TEXT_ALIGNMENT_LEFT = 0;
+  TiUISpy.TEXT_ALIGNMENT_RIGHT = 2;
+  TiUISpy.TEXT_AUTOCAPITALIZATION_ALL = 3;
+  TiUISpy.TEXT_AUTOCAPITALIZATION_NONE = 0;
+  TiUISpy.TEXT_AUTOCAPITALIZATION_SENTENCES = 2;
+  TiUISpy.TEXT_AUTOCAPITALIZATION_WORDS = 1;
+  TiUISpy.TEXT_ELLIPSIZE_TRUNCATE_END = 4;
+  TiUISpy.TEXT_ELLIPSIZE_TRUNCATE_MARQUEE = undefined;
+  TiUISpy.TEXT_ELLIPSIZE_TRUNCATE_MIDDLE = 5;
+  TiUISpy.TEXT_ELLIPSIZE_TRUNCATE_START = 3;
+  TiUISpy.TEXT_STYLE_BODY = 'UICTFontTextStyleBody';
+  TiUISpy.TEXT_STYLE_CAPTION1 = 'UICTFontTextStyleCaption1';
+  TiUISpy.TEXT_STYLE_CAPTION2 = 'UICTFontTextStyleCaption2';
+  TiUISpy.TEXT_STYLE_FOOTNOTE = 'UICTFontTextStyleFootnote';
+  TiUISpy.TEXT_STYLE_HEADLINE = 'UICTFontTextStyleHeadline';
+  TiUISpy.TEXT_STYLE_SUBHEADLINE = 'UICTFontTextStyleSubhead';
+  TiUISpy.TEXT_VERTICAL_ALIGNMENT_BOTTOM = 2;
+  TiUISpy.TEXT_VERTICAL_ALIGNMENT_CENTER = 0;
+  TiUISpy.TEXT_VERTICAL_ALIGNMENT_TOP = 1;
+  TiUISpy.UNIT_CM = 'cm';
+  TiUISpy.UNIT_DIP = 'dip';
+  TiUISpy.UNIT_IN = 'in';
+  TiUISpy.UNIT_MM = 'mm';
+  TiUISpy.UNIT_PX = 'px';
+  TiUISpy.UNKNOWN = 0;
+  TiUISpy.UPSIDE_PORTRAIT = 2;
+  TiUISpy.URL_ERROR_AUTHENTICATION = -1013;
+  TiUISpy.URL_ERROR_BAD_URL = -1000;
+  TiUISpy.URL_ERROR_CONNECT = -1004;
+  TiUISpy.URL_ERROR_FILE = -3001;
+  TiUISpy.URL_ERROR_FILE_NOT_FOUND = -1100;
+  TiUISpy.URL_ERROR_HOST_LOOKUP = -1003;
+  TiUISpy.URL_ERROR_REDIRECT_LOOP = -1007;
+  TiUISpy.URL_ERROR_SSL_FAILED = -1200;
+  TiUISpy.URL_ERROR_TIMEOUT = -1001;
+  TiUISpy.URL_ERROR_UNKNOWN = -1;
+  TiUISpy.URL_ERROR_UNSUPPORTED_SCHEME = -1002;
+
+  TiUISpy.AttributedString = '';
+
+  TiSpy.UI = TiUISpy;
+  TiSpy.UI.iOS = TiUISpy;
+
+  return TiSpy;
+};


### PR DESCRIPTION
This pull request is more of a RFC for the changes.

I need the ability to parse h1-h6's from html into attributed strings, but wanted it to be configurable in case there are more things to add in the future.