### PR TITLE
fix check for iOS to support iOS 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ if (parseInt(Ti.version.split('.')[0], 10) < 4) {
   ns = Ti.UI.iOS;
 }
 
-var ios = Ti.Platform.name === 'iPhone OS';
+var ios = Ti.Platform.name === 'iPhone OS' || Ti.Platform.name === 'iOS';
 
 // Custom matcher is a function to enable parsing of extra node types.
 // @return Object


### PR DESCRIPTION
Since iOS 10  [Ti.Platform.name](http://docs.appcelerator.com/platform/latest/#!/api/Titanium.Platform-property-name) property returns "iOS" for the iOS platform (iPhone, iPad, or iPod Touch). 

